### PR TITLE
chore: remove treemap visualization in this app

### DIFF
--- a/03_Components/Main/ConfirmedCityTreemap.server.R
+++ b/03_Components/Main/ConfirmedCityTreemap.server.R
@@ -1,20 +1,20 @@
-createConfirmedCityTreemap <- function(dataset) {
-  parent <- "県名"
-  child <- "市名"
-  value <- colnames(dataset)[ncol(dataset)]
-  setnames(dataset, value, "累計")
-  dataset %>%
-    e_charts() %>%
-    e_treemap(県名, 市名, 累計,
-      upperLabel = list(show = T, color = "#222"),
-      left = "1%", right = "1%", bottom = "10%"
-    ) %>%
-    e_tooltip() %>%
-    e_title(text = i18n$t("5月9までの市区町村の感染者数"), 
-            subtext = i18n$t("データソース：@kenmo_economics\n※陽性者数は居住地が判明した方のみを集計しているので、県の総計と一致しません。\n※5月9日以後のデータは収集されないため、グラフの更新も中止となります。"),
-            sublink = "https://twitter.com/kenmo_economics")
-}
+# createConfirmedCityTreemap <- function(dataset) {
+#   parent <- "県名"
+#   child <- "市名"
+#   value <- colnames(dataset)[ncol(dataset)]
+#   setnames(dataset, value, "累計")
+#   dataset %>%
+#     e_charts() %>%
+#     e_treemap(県名, 市名, 累計,
+#       upperLabel = list(show = T, color = "#222"),
+#       left = "1%", right = "1%", bottom = "10%"
+#     ) %>%
+#     e_tooltip() %>%
+#     e_title(text = i18n$t("5月9までの市区町村の感染者数"), 
+#             subtext = i18n$t("データソース：@kenmo_economics\n※陽性者数は居住地が判明した方のみを集計しているので、県の総計と一致しません。\n※5月9日以後のデータは収集されないため、グラフの更新も中止となります。"),
+#             sublink = "https://twitter.com/kenmo_economics")
+# }
 
-output$confirmedCityTreemap <- renderEcharts4r({
-  createConfirmedCityTreemap(confirmedCityTreemapData)
-})
+# output$confirmedCityTreemap <- renderEcharts4r({
+#   createConfirmedCityTreemap(confirmedCityTreemapData)
+# })

--- a/04_Pages/Main/Main.ui.R
+++ b/04_Pages/Main/Main.ui.R
@@ -59,12 +59,12 @@ fluidPage(
               uiOutput("confirmedHeatmapDoublingTimeOptions")
             )
           )
-        ),
-        # 市レベルの感染者数
-        tabPanel(
-          title = tagList(icon("grip-horizontal"), i18n$t("市区町村の感染者数")),
-          echarts4rOutput("confirmedCityTreemap", height = "600px") %>% withSpinner()
-        )
+        )# ,
+        # # 市レベルの感染者数
+        # tabPanel(
+        #   title = tagList(icon("grip-horizontal"), i18n$t("市区町村の感染者数")),
+        #   echarts4rOutput("confirmedCityTreemap", height = "600px") %>% withSpinner()
+        # )
       ),
       tags$hr(),
       # 各カテゴリの合計と増加分表示の説明ブロック

--- a/04_Pages/Pref/Fukuoka-UI.R
+++ b/04_Pages/Pref/Fukuoka-UI.R
@@ -51,8 +51,8 @@ fluidPage(
           echarts4rOutput("FukuokaInfectedRoute") %>% withSpinner()
         ),
         column(
-          width = 6,
-          echarts4rOutput("FukuokaResidentialTreeMap") %>% withSpinner()
+          width = 6 # ,
+          # echarts4rOutput("FukuokaResidentialTreeMap") %>% withSpinner()
         )
       ),
       footer = tags$small(icon("lightbulb"), i18n$t("凡例クリックすると表示・非表示の切替ができます。"))

--- a/global.R
+++ b/global.R
@@ -239,7 +239,7 @@ names(provinceSelector) <- sapply(provinceCode$`name-ja`, i18n$t)
 positiveDetail <- fread(paste0(DATA_PATH, "positiveDetail.csv"))
 
 # 市レベルの感染者数
-confirmedCityTreemapData <- fread(paste0(DATA_PATH, "Kenmo/confirmedNumberByCity.", languageSetting, ".csv"))
+# confirmedCityTreemapData <- fread(paste0(DATA_PATH, "Kenmo/confirmedNumberByCity.", languageSetting, ".csv"))
 
 # 詳細データ
 detail <- fread(paste0(DATA_PATH, "detail.csv"),

--- a/server.R
+++ b/server.R
@@ -11,7 +11,7 @@ shinyServer(function(input, output, session) {
   source(file = paste0(COMPONENT_PATH, "Main/Tendency.Confirmed.server.R"), local = T, encoding = "UTF-8")
   source(file = paste0(COMPONENT_PATH, "Main/ComparePref.server.R"), local = T, encoding = "UTF-8")
   source(file = paste0(COMPONENT_PATH, "Main/ConfirmedHeatmap.server.R"), local = T, encoding = "UTF-8")
-  source(file = paste0(COMPONENT_PATH, "Main/ConfirmedCityTreemap.server.R"), local = T, encoding = "UTF-8")
+  # source(file = paste0(COMPONENT_PATH, "Main/ConfirmedCityTreemap.server.R"), local = T, encoding = "UTF-8")
   source(file = paste0(COMPONENT_PATH, "Academic/onset2ConfirmedMap.server.R"), local = T, encoding = "UTF-8")
   source(file = paste0(COMPONENT_PATH, "Google/PrefMobility.server.R"), local = T, encoding = "UTF-8")
   source(file = paste0(PAGE_PATH, "World/World.server.R"), local = T, encoding = "UTF-8")


### PR DESCRIPTION
The interface of `e_treemap` has been changed since echarts4r v3.3 ( https://github.com/JohnCoene/echarts4r/pull/180 ), the dataset is not going to update anymore, and I need to update echarts4r to the latest github version, so remove those visualization.